### PR TITLE
Remove Conda update

### DIFF
--- a/notebook/Dockerfile
+++ b/notebook/Dockerfile
@@ -58,7 +58,6 @@ RUN mkdir $HOME/.jupyter \
     && $CONDA_DIR/bin/conda config --system --append channels conda-forge  \
     && $CONDA_DIR/bin/conda config --system --set auto_update_conda false  \
     && $CONDA_DIR/bin/conda config --system --set show_channel_urls true  \
-    && $CONDA_DIR/bin/conda update --all --quiet --yes  \
     && $CONDA_DIR/bin/conda install --yes --quiet 'mkl' jupyter 'notebook=5.7.*' $(while read requirement; do echo \'$requirement\'; done < /home/requirements.txt) \
     && $CONDA_DIR/bin/conda clean -tipsy \
     && $CONDA_DIR/bin/conda remove --quiet --yes --force qt pyqt \


### PR DESCRIPTION
The Conda update results in a unresolvable dependencies and prevents the notebook builds from completing. We will remove it so builds can complete. We should probably see if updating MINICONDA_VERSION will allow us to put the upgrade back.